### PR TITLE
Fix Bug in the Configuration Value for TS4231

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ $(PROJ).json: LighthouseTopLevel.v
 	yosys -p 'read_verilog LighthouseTopLevel.v; read_verilog  blackboxes.v; synth_ice40 -top LighthouseTopLevel; write_json $@'
 
 %.asc: %.json $(PIN_DEF)
-	nextpnr-ice40 --seed 4 --up5k --package sg48 --json $< --asc $@ --pcf $(PIN_DEF)
+	nextpnr-ice40 --seed 0 --up5k --package sg48 --json $< --asc $@ --pcf $(PIN_DEF)
 	python3 tools/update_bitstream_comment.py $@ "$(VERSION)"
 
 %.bin: %.asc

--- a/rtl/ts4231Configurator.v
+++ b/rtl/ts4231Configurator.v
@@ -45,7 +45,7 @@ module ts4231Configurator (
   reg prev_reconfigure = 0;
   reg config_prev_d = 0;
   reg [5:0] config_bit_counter = 0;
-  reg [14:0] config_value = {14'h392b, 1'b0};
+  reg [15:0] config_value = {15'h392b, 1'b0};
   reg config_bit = 0;
   reg [4:0] config_wait_counter = 0;
   always @(posedge clk) begin


### PR DESCRIPTION
[Line 78](https://github.com/bitcraze/lighthouse-fpga/blob/7700a4aadec7e3fdeb6fb2247829236dfbf07fe6/rtl/ts4231Configurator.v#L69) accesses bit 15 of "config_value" which is only 15 bit wide: [Link](https://github.com/bitcraze/lighthouse-fpga/blob/7700a4aadec7e3fdeb6fb2247829236dfbf07fe6/rtl/ts4231Configurator.v#L48)


**New code was tested on a HX8K board but not on the Lighthouse positioning deck itself!!**

